### PR TITLE
Multiteam groundwork

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,8 @@
     "no-caller": 2,
     "quotes": [
       2,
-      "single"
+      "single",
+      {"allowTemplateLiterals": true}
     ],
     "no-undef": 2,
     "no-unused-vars": 2,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ require('skellington')({
 
 ### slackToken
 
-Defaults to `process.env.SLACK_API_TOKEN`.
+If this is a single team bot, the Slack API token used to connect to the Slack API.
 
 ### plugins
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 let Botkit = require('botkit');
-let express = require('express');
 let _ = require('lodash');
+let express = require('express');
 
 module.exports = (config) => {
   _.defaults(config, {debug: false, plugins: []});
@@ -19,29 +19,20 @@ module.exports = (config) => {
     slackbotConfig.storage = config.storage;
   }
 
-  let server;
   let controller = Botkit.slackbot(slackbotConfig);
+  let server;
+
+  addHelpListeners(controller, config.plugins);
 
   if (config.port) {
     server = startServer(config, controller);
   }
 
-  addHelpListeners(controller, config.plugins);
-
   let bot = controller.spawn({
     token: config.slackToken
   });
 
-  bot.startRTM((err, connectedBot) => {
-    if (err) {
-      logError(controller, err, 'Error connecting to RTM');
-      return process.exit(1); // need the return for tests which mock our process.exit
-    }
-
-    _.forEach(config.plugins, (plugin) => {
-      plugin.init(controller, connectedBot, server);
-    });
-  });
+  startRtm(config, controller, bot, server);
 
   // restart if disconnected
   controller.on('rtm_close', (bot) => {
@@ -53,81 +44,93 @@ module.exports = (config) => {
       }
     });
   });
-
-  /**
-   * Starts an express server for slash commands
-   *
-   * @param config
-   * @param contoller
-   * @returns {*}
-   */
-  function startServer(config, contoller) {
-    let expressApp = express();
-
-    expressApp.listen(config.port);
-    contoller.log('listening on port ' + config.port);
-    return expressApp;
-  }
-
-  /**
-   * Adds all help listeners for plugins
-   *
-   * @param controller
-   * @param botName
-   * @param plugins
-   */
-  function addHelpListeners(controller, plugins) {
-
-    _.forEach(plugins, function(plugin) {
-      if (_.get(plugin, 'help.text') && _.get(plugin, 'help.command')) {
-        registerHelpListener(controller, plugin.help);
-      }
-    });
-
-    controller.hears('^help$', 'direct_mention,direct_message', function(bot, message) {
-      let helpCommands = _.chain(plugins)
-        .filter((plugin) => !!_.get(plugin, 'help.command'))
-        .map((plugin) => '`@' + bot.identity.name + ' help ' + _.get(plugin, 'help.command') + '`')
-        .value()
-        .join('\n');
-
-      if (!helpCommands.length) {
-        return bot.reply(message, 'I can\'t help you with anything right now. I still like you though :heart:');
-      }
-
-      return bot.reply(message, 'Here are some things I can help you with:\n' + helpCommands);
-    });
-  }
-
-  /**
-   * Adds a single help listener for a plugin
-   * @param controller
-   * @param helpInfo
-   */
-  function registerHelpListener(controller, helpInfo) {
-    console.log('registerHelpListener');
-    controller.hears('^help ' + helpInfo.command + '$', 'direct_mention,direct_message', function(bot, message) {
-      let replyText = helpInfo.text;
-
-      if (typeof helpInfo.text === 'function') {
-        let helpOpts = _.merge({botName: bot.identity.name}, _.pick(message, ['team', 'channel', 'user']));
-
-        replyText = helpInfo.text(helpOpts);
-      }
-
-      bot.reply(message, replyText);
-    });
-  }
-
-  /**
-   * Convenience method to log errors
-   *
-   * @param controller
-   * @param err
-   * @param message
-   */
-  function logError(controller, err, message) {
-    controller.log(message);
-    controller.log(err);
-  }
 };
+
+
+/**
+ * Starts an express server for slash commands
+ *
+ * @param config
+ * @param controller
+ */
+function startServer(config, controller) {
+  let expressApp = express();
+
+  expressApp.listen(config.port);
+  controller.log('listening on port ' + config.port);
+  return expressApp;
+}
+
+/**
+ * Adds all help listeners for plugins
+ *
+ * @param controller
+ * @param botName
+ * @param plugins
+ */
+function addHelpListeners(controller, plugins) {
+
+  _.forEach(plugins, function(plugin) {
+    if (_.get(plugin, 'help.text') && _.get(plugin, 'help.command')) {
+      registerHelpListener(controller, plugin.help);
+    }
+  });
+
+  controller.hears('^help$', 'direct_mention,direct_message', function(bot, message) {
+    let helpCommands = _.chain(plugins)
+      .filter((plugin) => !!_.get(plugin, 'help.command'))
+      .map((plugin) => '`@' + bot.identity.name + ' help ' + _.get(plugin, 'help.command') + '`')
+      .value()
+      .join('\n');
+
+    if (!helpCommands.length) {
+      return bot.reply(message, 'I can\'t help you with anything right now. I still like you though :heart:');
+    }
+
+    return bot.reply(message, 'Here are some things I can help you with:\n' + helpCommands);
+  });
+}
+
+/**
+ * Adds a single help listener for a plugin
+ * @param controller
+ * @param helpInfo
+ */
+function registerHelpListener(controller, helpInfo) {
+  controller.hears('^help ' + helpInfo.command + '$', 'direct_mention,direct_message', function(bot, message) {
+    let replyText = helpInfo.text;
+
+    if (typeof helpInfo.text === 'function') {
+      let helpOpts = _.merge({botName: bot.identity.name}, _.pick(message, ['team', 'channel', 'user']));
+
+      replyText = helpInfo.text(helpOpts);
+    }
+
+    bot.reply(message, replyText);
+  });
+}
+
+function startRtm(config, controller, bot, server) {
+  bot.startRTM((err, connectedBot) => {
+    if (err) {
+      logError(controller, err, 'Error connecting to RTM');
+      return process.exit(1); // need the return for tests which mock our process.exit
+    }
+
+    _.forEach(config.plugins, (plugin) => {
+      plugin.init(controller, connectedBot, server);
+    });
+  });
+}
+
+/**
+ * Convenience method to log errors
+ *
+ * @param controller
+ * @param err
+ * @param message
+ */
+function logError(controller, err, message) {
+  controller.log(message);
+  controller.log(err);
+}

--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@
 let Botkit = require('botkit');
 let express = require('express');
 let _ = require('lodash');
-let botCache = new Map(); // map of token to bot
 
 module.exports = (config) => {
-  _.defaults(config, {debug: false, plugins: [], slackToken: process.env.SLACK_API_TOKEN});
+  _.defaults(config, {debug: false, plugins: []});
 
   if (!Array.isArray(config.plugins)) {
     config.plugins = [config.plugins];
@@ -32,6 +31,7 @@ module.exports = (config) => {
   let bot = controller.spawn({
     token: config.slackToken
   });
+
   bot.startRTM((err, connectedBot) => {
     if (err) {
       logError(controller, err, 'Error connecting to RTM');
@@ -105,6 +105,7 @@ module.exports = (config) => {
    * @param helpInfo
    */
   function registerHelpListener(controller, helpInfo) {
+    console.log('registerHelpListener');
     controller.hears('^help ' + helpInfo.command + '$', 'direct_mention,direct_message', function(bot, message) {
       let replyText = helpInfo.text;
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -24,7 +24,10 @@ describe('Skellington', () => {
 
     botMock = {
       startRTM: sinon.stub(),
-      reply: sinon.stub()
+      reply: sinon.stub(),
+      identity: {
+        name: 'gazorpazorp'
+      }
     };
 
     controllerMock = {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -194,8 +194,6 @@ describe('Skellington', function() {
 
       skellington({plugins: [plugin, anotherPlugin, aThirdPlugin]});
 
-      console.log('callcount', controllerMock.hears.callCount);
-
       expect(controllerMock.hears.callCount).to.equal(3); // once for general help, twice for plugins with help text
 
       // call all the callbacks

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -8,7 +8,7 @@ let _ = require('lodash');
 
 chai.use(require('sinon-chai'));
 
-describe('Skellington', () => {
+describe('Skellington', function() {
   let skellington;
   let botkitMock;
   let controllerMock;
@@ -18,7 +18,7 @@ describe('Skellington', () => {
   let connectedBotMock;
   let exitOrig;
 
-  beforeEach(() => {
+  beforeEach(function() {
 
     connectedBotMock = {'team_info': {id: 'rickandmorty'}, identity: {name: 'butter-passer'}};
 
@@ -46,8 +46,6 @@ describe('Skellington', () => {
     };
     expressMock = sinon.stub().returns(expressAppMock);
 
-    process.env.SLACK_API_TOKEN = 'SNOWBALL';
-
     exitOrig = process.exit;
     process.exit = sinon.stub();
 
@@ -57,23 +55,22 @@ describe('Skellington', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(function() {
     process.exit = exitOrig;
   });
 
   describe('init', function() {
 
-    it('should initialize', () => {
-      skellington({});
+    it('should initialize', function() {
+      skellington({slackToken: 'abc123'});
 
       expect(botkitMock.slackbot).to.have.been.calledWith({debug: false});
-      expect(controllerMock.spawn).to.have.been.calledWith({token: process.env.SLACK_API_TOKEN});
       expect(expressMock).not.to.have.been.called;
       expect(botMock.startRTM).to.be.called;
       expect(controllerMock.on).to.be.calledWithMatch('rtm_close');
     });
 
-    it('should allow passed in configs', () => {
+    it('should allow passed in configs', function() {
       let storageMock = {};
 
       skellington({
@@ -89,15 +86,15 @@ describe('Skellington', () => {
     });
   });
 
-  describe('startRtm', () => {
+  describe('startRtm', function() {
     let callback;
 
-    beforeEach(() => {
+    beforeEach(function() {
       skellington({});
       callback = botMock.startRTM.args[0][0];
     });
 
-    it('should exit if there is an error connecting', () => {
+    it('should exit if there is an error connecting', function() {
       let error = new Error('GAZORPAZORP');
 
       callback(error);
@@ -106,31 +103,31 @@ describe('Skellington', () => {
       expect(process.exit).to.be.calledWith(1);
     });
 
-    describe('initialize plugins', () => {
+    describe('initialize plugins', function() {
       let plugin;
 
-      beforeEach(() => {
+      beforeEach(function() {
         botMock.startRTM.reset();
         plugin = {
           init: sinon.stub()
         };
       });
 
-      it('should initialize one plugin not in an array', () => {
+      it('should initialize one plugin not in an array', function() {
         skellington({plugins: plugin, port: 1234});
         botMock.startRTM.args[0][0](null, connectedBotMock);
 
         expect(plugin.init).to.have.been.calledWith(controllerMock, connectedBotMock, expressAppMock);
       });
 
-      it('should initialize one plugin in an array', () => {
+      it('should initialize one plugin in an array', function() {
         skellington({plugins: [plugin], port: 1234});
         botMock.startRTM.args[0][0](null, connectedBotMock);
 
         expect(plugin.init).to.have.been.calledWith(controllerMock, connectedBotMock, expressAppMock);
       });
 
-      it('should initialize multiple plugins', () => {
+      it('should initialize multiple plugins', function() {
         let anotherExternalBot = {
           init: sinon.stub()
         };
@@ -142,7 +139,7 @@ describe('Skellington', () => {
         expect(anotherExternalBot.init).to.have.been.calledWith(controllerMock, connectedBotMock, expressAppMock);
       });
 
-      it('should not pass an express app if port is not set', () => {
+      it('should not pass an express app if port is not set', function() {
         skellington({plugins: [plugin]});
         botMock.startRTM.args[0][0](null, connectedBotMock);
 
@@ -150,118 +147,119 @@ describe('Skellington', () => {
       });
     });
 
-    describe('register help listeners', () => {
-      let plugin;
-      let messageMock;
+  });
 
-      beforeEach(() => {
-        botMock.startRTM.reset();
-        plugin = {
-          init: sinon.stub()
-        };
+  describe('register help listeners', function() {
+    let plugin;
+    let messageMock;
 
-        messageMock = {
-          team: 'crystal',
-          channel: 'blue',
-          user: 'persuasion'
-        };
+    beforeEach(function() {
+      botMock.startRTM.reset();
+      plugin = {
+        init: sinon.stub()
+      };
+
+      messageMock = {
+        team: 'crystal',
+        channel: 'blue',
+        user: 'persuasion'
+      };
+    });
+
+    it('should register a listener if no plugins have help text', function() {
+      skellington({plugins: [plugin]});
+      expect(controllerMock.hears).to.have.been.calledOnce;
+
+      let callback = controllerMock.hears.args[0][2];
+
+      callback(botMock, messageMock);
+      expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^I can't help you/);
+    });
+
+    it('should register a listener for each plugin with help text', function() {
+      plugin.help = {
+        command: 'rick',
+        text: 'sanchez'
+      };
+
+      let anotherPlugin = {
+        init: sinon.stub(),
+        help: {
+          command: 'morty',
+          text: 'smith'
+        }
+      };
+
+      let aThirdPlugin = {init: sinon.stub()};
+
+      skellington({plugins: [plugin, anotherPlugin, aThirdPlugin]});
+
+      console.log('callcount', controllerMock.hears.callCount);
+
+      expect(controllerMock.hears.callCount).to.equal(3); // once for general help, twice for plugins with help text
+
+      // call all the callbacks
+      _.forEach(controllerMock.hears.args, function(args) {
+        args[2](botMock, messageMock);
       });
 
-      function startRtm(plugins) {
-        skellington({plugins: plugins});
-        botMock.startRTM.args[0][0](null, connectedBotMock);
-      }
+      expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^Here are some things/);
+      expect(botMock.reply).to.have.been.calledWith(messageMock, plugin.help.text);
+      expect(botMock.reply).to.have.been.calledWith(messageMock, anotherPlugin.help.text);
+    });
 
-      it('should register a listener if no plugins have help text', () => {
-        startRtm([plugin]);
-        expect(controllerMock.hears).to.have.been.calledOnce;
+    it('should handle a plugin help text callback', function() {
+      let helpTextCb = sinon.stub();
 
-        let callback = controllerMock.hears.args[0][2];
+      plugin.help = {
+        command: 'walter',
+        text: helpTextCb
+      };
 
-        callback(botMock, messageMock);
-        expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^I can't help you/);
+      botMock.identity = {name: 'rickandmorty'};
+
+      skellington({plugins: [plugin]});
+
+      // call all the callbacks
+      _.forEach(controllerMock.hears.args, function(args) {
+        args[2](botMock, messageMock);
       });
 
-      it('should register a listener for each plugin with help text', () => {
-        plugin.help = {
-          command: 'rick',
-          text: 'sanchez'
-        };
-
-        let anotherPlugin = {
-          init: sinon.stub(),
-          help: {
-            command: 'morty',
-            text: 'smith'
-          }
-        };
-
-        let aThirdPlugin = {init: sinon.stub()};
-
-        startRtm([plugin, anotherPlugin, aThirdPlugin]);
-        expect(controllerMock.hears.callCount).to.equal(3); // once for general help, twice for plugins with help text
-
-        // call all the callbacks
-        _.forEach(controllerMock.hears.args, function(args) {
-          args[2](botMock, messageMock);
-        });
-
-        expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^Here are some things/);
-        expect(botMock.reply).to.have.been.calledWith(messageMock, plugin.help.text);
-        expect(botMock.reply).to.have.been.calledWith(messageMock, anotherPlugin.help.text);
-      });
-
-      it('should handle a plugin help text callback', () => {
-        let helpTextCb = sinon.stub();
-
-        plugin.help = {
-          command: 'walter',
-          text: helpTextCb
-        };
-
-        botMock.identity = {name: 'rickandmorty'};
-
-        startRtm([plugin]);
-        // call all the callbacks
-        _.forEach(controllerMock.hears.args, function(args) {
-          args[2](botMock, messageMock);
-        });
-
-        expect(helpTextCb).to.have.been.calledWith({
-          botName: botMock.identity.name,
-          team: messageMock.team,
-          channel: messageMock.channel,
-          user: messageMock.user
-        });
+      expect(helpTextCb).to.have.been.calledWith({
+        botName: botMock.identity.name,
+        team: messageMock.team,
+        channel: messageMock.channel,
+        user: messageMock.user
       });
     });
   });
 
-  describe('rtm_close', () => {
+  describe('rtm_close', function() {
     let callback;
 
-    beforeEach(() => {
+    beforeEach(function() {
       skellington({});
 
       controllerMock.log.reset();
+
       botMock.startRTM.reset();
       botMock.startRTM.yields(null);
 
       callback = controllerMock.on.args[0][1];
     });
 
-    it('should reconnect', () => {
-      callback();
+    it('should reconnect', function() {
+      callback(botMock);
       expect(controllerMock.log).to.be.calledOnce;
       expect(botMock.startRTM).to.be.calledOnce;
     });
 
-    it('should exit if reconnect fails', () => {
+    it('should exit if reconnect fails', function() {
       let error = new Error('GAZORPAZORP');
 
       botMock.startRTM.yields(error);
 
-      callback();
+      callback(botMock);
       expect(botMock.startRTM).to.be.calledOnce;
       expect(controllerMock.log.callCount).to.equal(3);
       expect(controllerMock.log.args[2][0]).to.equal(error);


### PR DESCRIPTION
Lays groundwork for multiteam support:

- reworks how help listeners are registered: no longer relying on scoped variables, no longer registering after RTM connection. Help listeners will be registered exactly once.
- pulled out `rtm_closed` logic to use passed vars instead of scoped vars.
- drops support for autodetecting Slack API token: this will simplify configuration now that multiple connection configuration methods will be supported.
- updates corresponding tests