### PR TITLE
chore(package): update lodash to version 4.16.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/colestrode/skellington#readme",
   "dependencies": {
     "botkit": "0.4.0",
-    "lodash": "^4.6.1"
+    "lodash": "^4.16.5"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
https://greenkeeper.io/

Not sure why this wasn't automatically merged into master