### PR TITLE
adds botkit config stanza

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These types are mutually exclusive and which type you create depends on the opti
 
 ### botkit
 
-An object of options passed directly to `Botkit.slackbot`.
+An optional object of options passed directly to `Botkit.slackbot`.
 
 ### plugins
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Skellington will allow you to create a single team bot for that team or
 a Slack app capable of multi-team bots, slash commands, and incoming webhooks. 
 These types are mutually exclusive and which type you create depends on the options you pass.
 
-Skellington will accept any option to configure a Botkit Slack bot.
+### botkit
+
+An object of options passed directly to `Botkit.slackbot`.
 
 ### plugins
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,13 @@
 const Botkit = require('botkit')
 const _ = require('lodash')
 const connectedBots = new Set()
+const botkitDefaults = {
+  debug: false,
+  status_optout: true
+}
 
 module.exports = (config) => {
-  let controller = Botkit.slackbot(config.botkit || {})
+  let controller = Botkit.slackbot(_.defaults(config.botkit, botkitDefaults))
 
   validateConfig(config, controller)
   addHelpListeners(controller, config.plugins)
@@ -46,7 +50,7 @@ module.exports = (config) => {
  * @param controller
  */
 function validateConfig (config, controller) {
-  _.defaults(config, {debug: false, plugins: [], status_optout: true})
+  _.defaults(config, {debug: false, plugins: []})
 
   if (!Array.isArray(config.plugins)) {
     config.plugins = [config.plugins]

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 const connectedBots = new Set()
 
 module.exports = (config) => {
-  let controller = Botkit.slackbot(config.botkit)
+  let controller = Botkit.slackbot(config.botkit || {})
 
   validateConfig(config, controller)
   addHelpListeners(controller, config.plugins)

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 const connectedBots = new Set()
 
 module.exports = (config) => {
-  let controller = Botkit.slackbot(getSlackbotConfig(config))
+  let controller = Botkit.slackbot(config.botkit)
 
   validateConfig(config, controller)
   addHelpListeners(controller, config.plugins)
@@ -63,17 +63,6 @@ function validateConfig (config, controller) {
     logError(controller, new Error('Missing configuration. Config must include either slackToken AND/OR clientId, clientSecret, and port'))
     process.exit(1)
   }
-}
-
-/**
- * Given the passed config, returns an object with values relevant to configuring a Botkit slack bot
- *
- * @param config
- * @returns {{}}
- */
-function getSlackbotConfig (config) {
-  // omit config values not needed to configure a slackbot
-  return _.omit(config, ['clientId', 'clientSecret', 'plugins', 'port', 'redirectUri', 'scopes', 'slackToken', 'state'])
 }
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -88,15 +88,24 @@ describe('Skellington', function () {
       }
     })
 
-    it('should pass botkit config to botkit', function () {
+    it('should pass botkit config to botkit with defaults', function () {
+      const expectedConfg = _.clone(testConfig.botkit)
+      expectedConfg.debug = false
+      expectedConfg.status_optout = true
+
       skellington(testConfig)
-      expect(botkitMock.slackbot).to.have.been.calledWith(testConfig.botkit)
+      expect(botkitMock.slackbot).to.have.been.calledWith(expectedConfg)
     })
 
-    it('should pass empty config to botkit if no botkit config is passed', function () {
+    it('should pass defaults to botkit if no botkit config is passed', function () {
+      const expectedConfg = {
+        debug: false,
+        status_optout: true
+      }
+
       delete testConfig.botkit
       skellington(testConfig)
-      expect(botkitMock.slackbot).to.have.been.calledWith({})
+      expect(botkitMock.slackbot).to.have.been.calledWith(expectedConfg)
     })
 
     it('should take a non-array plugins and wrap it as an array', function () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -93,6 +93,12 @@ describe('Skellington', function () {
       expect(botkitMock.slackbot).to.have.been.calledWith(testConfig.botkit)
     })
 
+    it('should pass empty config to botkit if no botkit config is passed', function () {
+      delete testConfig.botkit
+      skellington(testConfig)
+      expect(botkitMock.slackbot).to.have.been.calledWith({})
+    })
+
     it('should take a non-array plugins and wrap it as an array', function () {
       testConfig.plugins = 'plugin'
       skellington(testConfig)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -74,7 +74,9 @@ describe('Skellington', function () {
 
     beforeEach(function () {
       testConfig = {
-        thisone: 'iscool',
+        botkit: {
+          thisone: 'iscool'
+        },
         clientId: 'nope',
         clientSecret: 'nope',
         plugins: ['nope'],
@@ -86,10 +88,9 @@ describe('Skellington', function () {
       }
     })
 
-    it('should strip skellington specific configs for slackbot initialization', function () {
+    it('should pass botkit config to botkit', function () {
       skellington(testConfig)
-      expect(botkitMock.slackbot).to.have.been.called
-      expect(botkitMock.slackbot.args[0][0]).to.have.keys(['thisone'])
+      expect(botkitMock.slackbot).to.have.been.calledWith(testConfig.botkit)
     })
 
     it('should take a non-array plugins and wrap it as an array', function () {


### PR DESCRIPTION
Closes #21 

I think we should hold off on the `type` option until we have a second implementation, that will keep the client implementation simple.