### PR TITLE
refactors app into stateless services

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,17 @@
 const Botkit = require('botkit')
 const _ = require('lodash')
 const debugLogger = require('./lib/debug-logger')
-const connectedTeams = new Set()
+const server = require('./lib/server')
+const help = require('./lib/help')
+const utils = require('./lib/utils')
+
 const botkitDefaults = {
   debug: false,
   status_optout: true
 }
 
 module.exports = (cfg) => {
+  const instance = {}
   const config = _.cloneDeep(cfg)
   const controller = Botkit.slackbot(getSlackbotConfig(config))
 
@@ -17,63 +21,23 @@ module.exports = (cfg) => {
 
   // start debugging before help listeners are added
   if (config.debug) {
-    module.exports.__config = config // expose internal config during debug mode
-    debugLogger(controller, config.debugOptions)
+    instance.__config = config // expose internal config during debug mode
+    debugLogger.addLogger(controller, config.debugOptions)
   }
 
-  addHelpListeners(controller, config.plugins)
+  help.addHelpListeners(controller, config.plugins)
 
   if (config.port) {
-    startServer(controller, config.port)
+    server.start(controller, config)
   }
 
   if (config.isSlackApp) {
-    startSlackApp(config, controller)
+    require('./lib/slack-app').start(controller, config)
   } else {
-    startSingleBot(config, controller)
+    require('./lib/single-team-bot').start(controller, config)
   }
 
-  // used for slack apps that will connect multiple bots
-  controller.on('create_bot', (bot) => {
-    const teamId = bot.config.id
-
-    // keep track of bots
-    if (!connectedTeams.has(teamId)) {
-      bot.startRTM((err, connectedBot) => {
-        if (err) {
-          return logError(controller, err, 'Could not connect bot to RTM')
-        }
-
-        connectedTeams.add(connectedBot.team_info.id)
-
-        botConnected(config.plugins, controller, connectedBot)
-        controller.log(`added bot ${identity(connectedBot)}`)
-      })
-    }
-  })
-
-  // restart if disconnected
-  controller.on('rtm_close', (bot) => {
-    controller.log(`rtm closed, attempting to reconnect bot ${identity(bot)}`)
-
-    bot.startRTM((err) => {
-      if (!err) {
-        return controller.log(`reconnected bot ${identity(bot)}`)
-      }
-
-      logError(controller, err, `Could not re-connect bot to RTM ${identity(bot)}`)
-
-      if (config.isSlackApp) {
-        connectedTeams.delete(bot.team_info.id)
-      } else if (config.exitOnRtmFailure !== false) {
-        process.exit(1)
-      }
-    })
-  })
-}
-
-function identity (bot) {
-  return JSON.stringify({name: bot.identity.name, id: bot.identity.id})
+  return instance
 }
 
 /**
@@ -94,6 +58,7 @@ function formatConfig (config, controller) {
   _.defaults(config, {debug: false, plugins: []})
 
   config.debugOptions = config.debugOptions || {}
+  config.connectedTeams = new Set()
 
   if (!Array.isArray(config.plugins)) {
     config.plugins = [config.plugins]
@@ -110,203 +75,8 @@ function formatConfig (config, controller) {
   config.isSlackApp = !config.slackToken
 
   if (!config.slackToken && !(config.clientId && config.clientSecret && config.port)) {
-    logError(controller, new Error('Missing configuration. Config must include either slackToken AND/OR clientId, clientSecret, and port'))
+    utils.logError(controller, new Error('Missing configuration. Config must include either slackToken AND/OR clientId, clientSecret, and port'))
     process.exit(1)
   }
 }
 
-/**
- * Starts a single-team bot, i.e., not a Slack app (no slash commands, no incoming webhooks, etc.)
- *
- * @param config
- * @param controller
- */
-function startSingleBot (config, controller) {
-  let bot = controller.spawn({
-    token: config.slackToken
-  })
-
-  bot.startRTM((err, connectedBot) => {
-    if (err) {
-      logError(controller, err, 'Could not connect bot to RTM') // what information could we log??
-      if (config.exitOnRtmFailure !== false) {
-        return process.exit(1)
-      }
-      return
-    }
-
-    connectedTeams.add(bot.team_info.id)
-    initializePlugins(config.plugins, controller, connectedBot)
-    botConnected(config.plugins, controller, connectedBot)
-  })
-}
-
-/**
- * Starts a slack app and adds support for a incoming webhooks, slash commands, and bot users that can be invited to multiple teams
- *
- * @param config
- * @param controller
- */
-function startSlackApp (config, controller) {
-  controller.configureSlackApp({
-    clientId: config.clientId,
-    clientSecret: config.clientSecret,
-    redirectUri: config.redirectUri, // optional
-    state: config.state,
-    scopes: config.scopes
-  })
-
-  initializePlugins(config.plugins, controller, null)
-
-  controller.storage.teams.all((err, teams) => {
-    if (err) {
-      logError(controller, err, 'Could not reconnect teams')
-      return process.exit(1)
-    }
-
-    _.forEach(teams, (team) => {
-      if (!team.bot) return
-
-      controller.spawn(team).startRTM((err, connectedBot) => {
-        if (!err) {
-          connectedTeams.add(team.id)
-          botConnected(config.plugins, controller, connectedBot)
-          controller.log('bot added from storage', connectedBot.identity.id)
-          return
-        }
-
-        logError(controller, err, `Could not reconnect bot to team ${team.id}`)
-        if (err === 'account_inactive' || err === 'invalid_auth') {
-          controller.log(`authentication revoked for for ${team.id}`)
-          delete team.bot
-          controller.storage.teams.save(team, function () {}) // fail silently
-        }
-      })
-    })
-  })
-}
-
-/**
- * Starts an express server for slash commands, incoming webhooks, and OAuth flow
- *
- * @param config
- * @param controller
- */
-function startServer (controller, port) {
-  controller.setupWebserver(port, (err) => {
-    if (err) {
-      return logError(controller, err, `Error setting up server on port ${port}`)
-    }
-
-    controller.createWebhookEndpoints(controller.webserver) // synchronous method
-
-    controller.createOauthEndpoints(controller.webserver, (err, req, res) => {
-      if (err) {
-        logError(controller, err, `Error setting up OAuth endpoints`)
-        return res.status(500).send({message: `Error setting up OAuth endpoints`})
-      }
-      // TODO need to redirect
-      res.status(200).send({message: `Success!`})
-    })
-  })
-}
-
-/**
- * Adds all help listeners for plugins
- *
- * @param controller
- * @param botName
- * @param plugins
- */
-function addHelpListeners (controller, plugins) {
-  _.forEach(plugins, (plugin) => {
-    if (_.get(plugin, 'help.text') && _.get(plugin, 'help.command')) {
-      registerHelpListener(controller, plugin.help)
-    }
-  })
-
-  controller.hears('^help$', 'direct_mention,direct_message', (bot, message) => {
-    let helpCommands = _.chain(plugins)
-      .filter((plugin) => !!_.get(plugin, 'help.command'))
-      .map((plugin) => `\`@${bot.identity.name} help ${_.get(plugin, 'help.command')}\``)
-      .value()
-      .join('\n')
-
-    if (!helpCommands.length) {
-      return bot.reply(message, 'I can\'t help you with anything right now. I still like you though :heart:')
-    }
-
-    return bot.reply(message, 'Here are some things I can help you with:\n' + helpCommands)
-  })
-}
-
-/**
- * Adds a single help listener for a plugin
- *
- * @param controller
- * @param helpInfo
- */
-function registerHelpListener (controller, helpInfo) {
-  controller.hears('^help ' + helpInfo.command + '$', 'direct_mention,direct_message', (bot, message) => {
-    let replyText = helpInfo.text
-
-    if (typeof helpInfo.text === 'function') {
-      let helpOpts = _.merge({botName: bot.identity.name}, _.pick(message, ['team', 'channel', 'user']))
-
-      replyText = helpInfo.text(helpOpts)
-    }
-
-    bot.reply(message, replyText)
-  })
-}
-
-/**
- * Initializes plugins, called on Skellington initialization
- *
- * @param plugins
- * @param controller
- * @param bot
- */
-function initializePlugins (plugins, controller, bot) {
-  bot = bot || null // bot may be undefined for multi-teams
-  _.forEach(plugins, (plugin) => {
-    if (_.isFunction(plugin.init)) {
-      try {
-        plugin.init(controller, bot, controller.webserver)
-      } catch (err) {
-        logError(controller, err, 'error calling init on plugin')
-      }
-    }
-  })
-}
-
-/**
- * Calls plugin botConnected callbacks when a bot is added
- *
- * @param plugins
- * @param controller
- * @param bot
- */
-function botConnected (plugins, controller, bot) {
-  _.forEach(plugins, (plugin) => {
-    if (_.isFunction(plugin.botConnected)) {
-      try {
-        plugin.botConnected(controller, bot)
-      } catch (err) {
-        logError(controller, err, 'error calling botConnected on plugin')
-      }
-    }
-  })
-}
-
-/**
- * Convenience method to log errors
- *
- * @param controller
- * @param err
- * @param message
- */
-function logError (controller, err, message) {
-  controller.log(message)
-  controller.log(err)
-}

--- a/lib/debug-logger.js
+++ b/lib/debug-logger.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = function (controller, config) {
+module.exports.addLogger = (controller, config) => {
   const hearsOrig = controller.hears.bind(controller)
   const formatter = config.formatter || defaultFormatter
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const _ = require('lodash')
+
+/**
+ * Adds all help listeners for plugins
+ *
+ * @param controller
+ * @param botName
+ * @param plugins
+ */
+module.exports.addHelpListeners = (controller, plugins) => {
+  _.forEach(plugins, (plugin) => {
+    if (_.get(plugin, 'help.text') && _.get(plugin, 'help.command')) {
+      registerHelpListener(controller, plugin.help)
+    }
+  })
+
+  controller.hears('^help$', 'direct_mention,direct_message', (bot, message) => {
+    let helpCommands = _.chain(plugins)
+      .filter((plugin) => !!_.get(plugin, 'help.command'))
+      .map((plugin) => `\`@${bot.identity.name} help ${_.get(plugin, 'help.command')}\``)
+      .value()
+      .join('\n')
+
+    if (!helpCommands.length) {
+      return bot.reply(message, 'I can\'t help you with anything right now. I still like you though :heart:')
+    }
+
+    return bot.reply(message, 'Here are some things I can help you with:\n' + helpCommands)
+  })
+}
+
+/**
+ * Adds a single help listener for a plugin
+ *
+ * @param controller
+ * @param helpInfo
+ */
+function registerHelpListener (controller, helpInfo) {
+  controller.hears('^help ' + helpInfo.command + '$', 'direct_mention,direct_message', (bot, message) => {
+    let replyText = helpInfo.text
+
+    if (typeof helpInfo.text === 'function') {
+      let helpOpts = _.merge({botName: bot.identity.name}, _.pick(message, ['team', 'channel', 'user']))
+
+      replyText = helpInfo.text(helpOpts)
+    }
+
+    bot.reply(message, replyText)
+  })
+}

--- a/lib/plugin-lifecycle.js
+++ b/lib/plugin-lifecycle.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const utils = require('./utils')
+const _ = require('lodash')
+
+/**
+ * Initializes plugins, called on Skellington initialization
+ *
+ * @param plugins
+ * @param controller
+ * @param bot
+ */
+module.exports.initialize = (plugins, controller, bot) => {
+  bot = bot || null // bot may be undefined for multi-teams
+  _.forEach(plugins, (plugin) => {
+    if (_.isFunction(plugin.init)) {
+      try {
+        plugin.init(controller, bot, controller.webserver)
+      } catch (err) {
+        utils.logError(controller, err, `error calling init on plugin`)
+      }
+    }
+  })
+}
+
+/**
+ * Calls plugin botConnected callbacks when a bot is added
+ *
+ * @param plugins
+ * @param controller
+ * @param bot
+ */
+module.exports.botConnected = (plugins, controller, bot) => {
+  _.forEach(plugins, (plugin) => {
+    if (_.isFunction(plugin.botConnected)) {
+      try {
+        plugin.botConnected(controller, bot)
+      } catch (err) {
+        utils.logError(controller, err, `error calling botConnected on plugin`)
+      }
+    }
+  })
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const utils = require('./utils')
+
+/**
+ * Starts an express server for slash commands, incoming webhooks, and OAuth flow
+ *
+ * @param controller
+ * @param config
+ */
+module.exports.start = (controller, config) => {
+  controller.setupWebserver(config.port, (err) => {
+    if (err) {
+      return utils.logError(controller, err, `Error setting up server on port ${config.port}`)
+    }
+
+    controller.createWebhookEndpoints(controller.webserver) // synchronous method
+
+    controller.createOauthEndpoints(controller.webserver, (err, req, res) => {
+      if (err) {
+        utils.logError(controller, err, `Error setting up OAuth endpoints`)
+        return res.status(500).send({message: `Error setting up OAuth endpoints`})
+      }
+
+      // TODO need to redirect
+      res.status(200).send({message: `Success!`})
+    })
+  })
+}

--- a/lib/single-team-bot.js
+++ b/lib/single-team-bot.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const lifecycle = require('./plugin-lifecycle')
+const utils = require('./utils')
+const _ = require('lodash')
+
+/**
+ * Starts a single-team bot, i.e., not a Slack app (no slash commands, no incoming webhooks, etc.)
+ *
+ * @param config
+ * @param controller
+ */
+module.exports.start = (controller, config) => {
+  controller.spawn({
+    token: config.slackToken
+  }).startRTM((err, connectedBot) => {
+    if (!err) {
+      controller.on('rtm_close', _.partial(rtmCloseListener, controller, config))
+      lifecycle.initialize(config.plugins, controller, connectedBot)
+      lifecycle.botConnected(config.plugins, controller, connectedBot)
+      return
+    }
+
+    utils.logError(controller, err, 'Could not connect bot to RTM')
+    if (config.exitOnRtmFailure !== false) {
+      return process.exit(1)
+    }
+  })
+}
+
+function rtmCloseListener (controller, config, bot) {
+  controller.log(`rtm closed, attempting to reconnect bot ${utils.identity(bot)}`)
+
+  bot.startRTM((err) => {
+    if (!err) {
+      return controller.log(`reconnected bot ${utils.identity(bot)}`)
+    }
+
+    utils.logError(controller, err, `Could not re-connect bot to RTM ${utils.identity(bot)}`)
+
+    if (config.exitOnRtmFailure !== false) {
+      process.exit(1)
+    }
+  })
+}

--- a/lib/slack-app.js
+++ b/lib/slack-app.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const lifecycle = require('./plugin-lifecycle')
+const utils = require('./utils')
+const _ = require('lodash')
+
+/**
+ * Starts a slack app and adds support for a incoming webhooks, slash commands, and bot users that can be invited to multiple teams
+ *
+ * @param controller
+ * @param config
+ */
+module.exports.start = (controller, config) => {
+  controller.configureSlackApp({
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    redirectUri: config.redirectUri, // optional
+    state: config.state,
+    scopes: config.scopes
+  })
+
+  lifecycle.initialize(config.plugins, controller, null)
+
+  controller.storage.teams.all((err, teams) => {
+    if (err) {
+      utils.logError(controller, err, 'Could not reconnect teams')
+      return process.exit(1)
+    }
+
+    _.forEach(teams, (team) => {
+      if (!team.bot) return
+      controller.spawn(team).startRTM(_.partial(onStartRtm, controller, config, team))
+    })
+  })
+
+  controller.on('create_bot', _.partial(createBot, controller, config))
+  controller.on('rtm_close', _.partial(onRtmClose, controller, config))
+}
+
+function createBot (controller, config, bot) {
+  const teamId = bot.config.id
+
+  // keep track of bots
+  if (!config.connectedTeams.has(teamId)) {
+    bot.startRTM((err, connectedBot) => {
+      if (err) {
+        return utils.logError(controller, err, 'Could not connect bot to RTM')
+      }
+
+      config.connectedTeams.add(connectedBot.team_info.id)
+
+      lifecycle.botConnected(config.plugins, controller, connectedBot)
+      controller.log(`added bot ${utils.identity(connectedBot)}`)
+    })
+  }
+}
+
+function onRtmClose (controller, config, bot) {
+  controller.log(`rtm closed, attempting to reconnect bot ${utils.identity(bot)}`)
+
+  bot.startRTM((err) => {
+    if (!err) {
+      return controller.log(`reconnected bot ${utils.identity(bot)}`)
+    }
+
+    utils.logError(controller, err, `Could not re-connect bot to RTM ${utils.identity(bot)}`)
+    config.connectedTeams.delete(bot.team_info.id)
+  })
+}
+
+function onStartRtm (controller, config, team, err, connectedBot) {
+  if (!err) {
+    config.connectedTeams.add(team.id)
+    lifecycle.botConnected(config.plugins, controller, connectedBot)
+    controller.log('bot added from storage', connectedBot.identity.id)
+    return
+  }
+
+  utils.logError(controller, err, `Could not reconnect bot to team ${team.id}`)
+  if (err === 'account_inactive' || err === 'invalid_auth') {
+    controller.log(`authentication revoked for for ${team.id}`)
+    delete team.bot
+    controller.storage.teams.save(team, function () {}) // fail silently
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Logs an error to the `controller.error` method
+ *
+ * @param controller
+ * @param err {Error} The error object to log
+ * @param message {String} A user-facing error message
+ */
+module.exports.logError = (controller, err, message) => {
+  controller.error(message)
+  controller.error(err)
+}
+
+/**
+ * Returns a String version of this bot's identity.
+ * Useful for logging messages.
+ *
+ * @param bot
+ * @returns {String} A stringified version of the bot's identity
+ */
+module.exports.identity = (bot) => {
+  return JSON.stringify({name: bot.identity.name, id: bot.identity.id})
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -12,48 +12,16 @@ describe('Skellington', function () {
   let skellington
   let botkitMock
   let controllerMock
-  let botMock
-  let storageMock
   let err
   let debugLoggerMock
-
-  function getOnCallback (eventName) {
-    return _.find(controllerMock.on.args, (args) => {
-      return args[0] === eventName
-    })[1]
-  }
+  let serverMock
+  let helpMock
+  let utilsMock
+  let singleBotMock
+  let slackAppMock
 
   beforeEach(function () {
-    botMock = {
-      startRTM: sinon.stub().yields(null, botMock),
-      reply: sinon.stub(),
-      identity: {
-        name: 'gazorpazorp'
-      },
-      team_info: {
-        id: 'richsanchez'
-      }
-    }
-
-    storageMock = {
-      teams: {
-        all: sinon.stub().yields(null),
-        save: sinon.stub().yields(null)
-      }
-    }
-
-    controllerMock = {
-      hears: sinon.stub(),
-      spawn: sinon.stub().returns(botMock),
-      log: sinon.stub(),
-      on: sinon.stub(),
-      configureSlackApp: sinon.stub(),
-      setupWebserver: sinon.stub().yields(null),
-      createWebhookEndpoints: sinon.stub(),
-      createOauthEndpoints: sinon.stub(),
-      webserver: 'webserver',
-      storage: storageMock
-    }
+    controllerMock = {}
 
     botkitMock = {
       slackbot: sinon.stub().returns(controllerMock)
@@ -63,11 +31,38 @@ describe('Skellington', function () {
 
     err = new Error('DING!')
 
-    debugLoggerMock = sinon.stub()
+    debugLoggerMock = {
+      addLogger: sinon.stub()
+    }
+
+    serverMock = {
+      start: sinon.stub()
+    }
+
+    helpMock = {
+      addHelpListeners: sinon.stub()
+    }
+
+    utilsMock = {
+      logError: sinon.stub()
+    }
+
+    singleBotMock = {
+      start: sinon.stub()
+    }
+
+    slackAppMock = {
+      start: sinon.stub()
+    }
 
     skellington = proxyquire('../index', {
       'botkit': botkitMock,
-      './lib/debug-logger': debugLoggerMock
+      './lib/debug-logger': debugLoggerMock,
+      './lib/server': serverMock,
+      './lib/help': helpMock,
+      './lib/utils': utilsMock,
+      './lib/slack-app': slackAppMock,
+      './lib/single-team-bot': singleBotMock
     })
   })
 
@@ -120,17 +115,17 @@ describe('Skellington', function () {
     it('should take a non-array plugins and wrap it as an array', function () {
       testConfig.plugins = 'plugin'
       testConfig.debug = true
-      skellington(testConfig)
-      expect(skellington.__config.plugins).to.be.an('array')
+      const instance = skellington(testConfig)
+      expect(instance.__config.plugins).to.be.an('array')
     })
 
     it('should flatten scopes', function () {
       testConfig.scopes = ['a']
       testConfig.plugins = [{scopes: ['b', 'c'], init: noop}, {scopes: ['c', 'd'], init: noop}]
       testConfig.debug = true
-      skellington(testConfig)
+      const instance = skellington(testConfig)
 
-      expect(skellington.__config.scopes.sort()).to.deep.equal(['a', 'b', 'c', 'd'])
+      expect(instance.__config.scopes.sort()).to.deep.equal(['a', 'b', 'c', 'd'])
     })
 
     it('should exit if required configs are missing', function () {
@@ -147,6 +142,54 @@ describe('Skellington', function () {
     })
   })
 
+  describe('init', function() {
+    let testConfig
+
+    beforeEach(function() {
+      testConfig = {
+        debug: true,
+        botkit: {
+          thisone: 'iscool'
+        },
+        plugins: ['plugin'],
+        port: 'port',
+        slackToken: 'token'
+      }
+    })
+
+    it('should add help listeners', function() {
+      skellington(testConfig)
+      expect(helpMock.addHelpListeners).to.have.been.calledWith(controllerMock, testConfig.plugins)
+    })
+
+    it('should set up a webserver if port is passed', function() {
+      const instance = skellington(testConfig)
+      expect(serverMock.start).to.have.been.calledWith(controllerMock, instance.__config)
+    })
+
+    it('should not set up a webserver if port is not pased', function() {
+      delete testConfig.port
+      skellington(testConfig)
+      expect(serverMock.start).not.to.have.been.called
+    })
+
+    it('should set up a single team bot if slack token is passed', function() {
+      const instance = skellington(testConfig)
+      expect(singleBotMock.start).to.have.been.calledWith(controllerMock, instance.__config)
+      expect(slackAppMock.start).not.to.have.been.called
+    })
+
+    it('should set up a slack app if slackToken is missing', function() {
+      testConfig.clientId = 'the one who knocks'
+      testConfig.clientSecret = 'shhhh'
+      delete testConfig.slackToken
+
+      const instance = skellington(testConfig)
+      expect(slackAppMock.start).to.have.been.calledWith(controllerMock, instance.__config)
+      expect(singleBotMock.start).not.to.have.been.called
+    })
+  })
+
   describe('debug', function () {
     let testConfig
 
@@ -157,11 +200,22 @@ describe('Skellington', function () {
       }
     })
 
+    it('should not expose config if debug is false', function() {
+      const instance = skellington(testConfig)
+      expect(instance.__config).not.to.exist
+    })
+
+    it('should expose config if debug is true', function() {
+      testConfig.debug = true
+      const instance = skellington(testConfig)
+      expect(instance.__config).to.exist
+    })
+
     it('should not set up debug logger if debug is false', function () {
       skellington(testConfig)
       const botkitDebug = botkitMock.slackbot.args[0][0].debug
 
-      expect(debugLoggerMock).not.to.have.been.calledWith(controllerMock, {})
+      expect(debugLoggerMock.addLogger).not.to.have.been.calledWith(controllerMock, {})
       expect(botkitDebug).to.be.false
     })
 
@@ -170,9 +224,9 @@ describe('Skellington', function () {
       skellington(testConfig)
       const botkitDebug = botkitMock.slackbot.args[0][0].debug
 
-      expect(debugLoggerMock).not.to.have.been.calledWith(controllerMock, testConfig.debugOptions)
+      expect(debugLoggerMock.addLogger).not.to.have.been.calledWith(controllerMock, testConfig.debugOptions)
       expect(botkitDebug).to.be.false
-    });
+    })
 
     it('should set up debug logger and botkit logging if debug is true', function () {
       testConfig.debug = true
@@ -180,7 +234,7 @@ describe('Skellington', function () {
       skellington(testConfig)
       const botkitDebug = botkitMock.slackbot.args[0][0].debug
 
-      expect(debugLoggerMock).to.have.been.called
+      expect(debugLoggerMock.addLogger).to.have.been.called
       expect(botkitDebug).to.be.true
     })
 
@@ -191,453 +245,8 @@ describe('Skellington', function () {
       skellington(testConfig)
       const botkitDebug = botkitMock.slackbot.args[0][0].debug
 
-      expect(debugLoggerMock).to.have.been.called
+      expect(debugLoggerMock.addLogger).to.have.been.called
       expect(botkitDebug).to.be.false
     })
-  })
-
-  describe('register help listeners', function () {
-    let plugin
-    let messageMock
-
-    beforeEach(function () {
-      botMock.startRTM.reset()
-      plugin = {
-        init: sinon.stub()
-      }
-
-      messageMock = {
-        team: 'crystal',
-        channel: 'blue',
-        user: 'persuasion'
-      }
-    })
-
-    it('should register a listener if no plugins have help text', function () {
-      skellington({plugins: [plugin]})
-      expect(controllerMock.hears).to.have.been.calledOnce
-
-      let callback = controllerMock.hears.args[0][2]
-
-      callback(botMock, messageMock)
-      expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^I can't help you/)
-    })
-
-    it('should register a listener for each plugin with help text', function () {
-      plugin.help = {
-        command: 'rick',
-        text: 'sanchez'
-      }
-
-      let anotherPlugin = {
-        init: sinon.stub(),
-        help: {
-          command: 'morty',
-          text: 'smith'
-        }
-      }
-
-      let aThirdPlugin = {init: sinon.stub()}
-
-      skellington({plugins: [plugin, anotherPlugin, aThirdPlugin]})
-
-      expect(controllerMock.hears.callCount).to.equal(3) // once for general help, twice for plugins with help text
-
-      // call all the callbacks
-      _.forEach(controllerMock.hears.args, function (args) {
-        args[2](botMock, messageMock)
-      })
-
-      expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^Here are some things/)
-      expect(botMock.reply).to.have.been.calledWith(messageMock, plugin.help.text)
-      expect(botMock.reply).to.have.been.calledWith(messageMock, anotherPlugin.help.text)
-    })
-
-    it('should handle a plugin help text callback', function () {
-      let helpTextCb = sinon.stub()
-
-      plugin.help = {
-        command: 'walter',
-        text: helpTextCb
-      }
-
-      botMock.identity = {name: 'rickandmorty'}
-
-      skellington({plugins: [plugin]})
-
-      // call all the callbacks
-      _.forEach(controllerMock.hears.args, function (args) {
-        args[2](botMock, messageMock)
-      })
-
-      expect(helpTextCb).to.have.been.calledWith({
-        botName: botMock.identity.name,
-        team: messageMock.team,
-        channel: messageMock.channel,
-        user: messageMock.user
-      })
-    })
-  })
-
-  describe('server', function () {
-    let testConfig
-
-    beforeEach(function () {
-      testConfig = {slackToken: 'walterwhite', port: 1234}
-    })
-
-    it('should set up a server if port is passed', function () {
-      skellington(testConfig)
-      expect(controllerMock.setupWebserver).to.have.been.calledWith(1234)
-      expect(controllerMock.createWebhookEndpoints).to.have.been.calledWith(controllerMock.webserver)
-      expect(controllerMock.createOauthEndpoints).to.have.been.calledWith(controllerMock.webserver)
-    })
-
-    it('should not set up server if port is missing', function () {
-      delete testConfig.port
-      skellington(testConfig)
-      expect(controllerMock.setupWebserver).not.to.have.been.called
-      expect(controllerMock.createWebhookEndpoints).not.to.have.been.called
-      expect(controllerMock.createOauthEndpoints).not.to.have.been.called
-    })
-
-    it('should not create endpoints if server is not created', function () {
-      controllerMock.setupWebserver.yields(err)
-      skellington(testConfig)
-      expect(controllerMock.setupWebserver).to.have.been.called
-      expect(controllerMock.createWebhookEndpoints).not.to.have.been.called
-      expect(controllerMock.createOauthEndpoints).not.to.have.been.called
-    })
-
-    describe('Oauth callback', function () {
-      let oauthCallback
-      let reqMock
-      let resMock
-
-      beforeEach(function () {
-        skellington(testConfig)
-        oauthCallback = controllerMock.createOauthEndpoints.args[0][1]
-
-        reqMock = {}
-        resMock = {
-          status: sinon.stub(),
-          send: sinon.stub()
-        }
-
-        resMock.status.returns(resMock)
-      })
-
-      it('should respond with 200 and success', function () {
-        oauthCallback(null, reqMock, resMock)
-        expect(resMock.status).to.have.been.calledWith(200)
-        expect(resMock.send).to.have.been.called
-      })
-
-      it('should respond with a 500 and error if oauth fails', function () {
-        controllerMock.log.reset()
-
-        oauthCallback(err, reqMock, resMock)
-        expect(controllerMock.log).to.have.been.calledWith(err)
-        expect(resMock.status).to.have.been.calledWith(500)
-        expect(resMock.send).to.have.been.called
-      })
-    })
-  })
-
-  describe('startSlackapp', function () {
-    let testConfig
-    let plugin
-    let teams
-
-    beforeEach(function () {
-      plugin = {
-        init: sinon.stub(),
-        botConnected: sinon.stub()
-      }
-
-      testConfig = {
-        port: 1234,
-        clientId: 'walterwhite',
-        clientSecret: 'heisenberg',
-        redirectUri: 'granitestate',
-        plugins: [plugin],
-        state: 'newmexico',
-        scopes: ['a']
-      }
-
-      teams = [{bot: 'team1'}, {bot: 'team2'}]
-      storageMock.teams.all.yields(null, teams)
-    })
-
-    it('should configure a slack app and initialize plugins', function () {
-      botMock.startRTM.yields(null, botMock)
-
-      skellington(testConfig)
-      expect(controllerMock.configureSlackApp).to.have.been.calledWith({
-        clientId: testConfig.clientId,
-        clientSecret: testConfig.clientSecret,
-        redirectUri: testConfig.redirectUri, // optional
-        state: testConfig.state,
-        scopes: testConfig.scopes
-      })
-
-      expect(plugin.init).to.have.been.calledWith(controllerMock, null, controllerMock.webserver)
-    })
-
-    it('should read teams from storage and reconnnect them', function () {
-      skellington(testConfig)
-
-      expect(storageMock.teams.all).to.have.been.called
-      expect(controllerMock.spawn).to.have.been.calledTwice
-      expect(botMock.startRTM).to.have.been.called
-      expect(plugin.botConnected).to.have.been.called
-    })
-
-    it('should not start rtm if team does not have a bot', function () {
-      teams = [{}, {}]
-      storageMock.teams.all.yields(null, teams)
-      skellington(testConfig)
-
-      expect(storageMock.teams.all).to.have.been.called
-      expect(controllerMock.spawn).not.to.have.been.calledTwice
-      expect(botMock.startRTM).not.to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-
-    it('should exit if it cannot read teams from storage', function () {
-      storageMock.teams.all.yields(err)
-      skellington(testConfig)
-
-      expect(storageMock.teams.all).to.have.been.called
-      expect(controllerMock.spawn).not.to.have.been.calledTwice
-      expect(botMock.startRTM).not.to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-
-    it('should remove team for account_inactive error', function () {
-      botMock.startRTM.yields('account_inactive')
-      skellington(testConfig)
-
-      expect(storageMock.teams.all).to.have.been.called
-      expect(controllerMock.spawn).to.have.been.calledTwice
-      expect(botMock.startRTM).to.have.been.called
-      expect(storageMock.teams.save).to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-
-    it('should remove team for invalid_auth error', function () {
-      botMock.startRTM.yields('invalid_auth')
-      skellington(testConfig)
-
-      expect(storageMock.teams.all).to.have.been.called
-      expect(controllerMock.spawn).to.have.been.calledTwice
-      expect(botMock.startRTM).to.have.been.called
-      expect(storageMock.teams.save).to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-
-    it('should not remove team for other errors', function () {
-      botMock.startRTM.yields('two dots')
-      skellington(testConfig)
-
-      expect(storageMock.teams.all).to.have.been.called
-      expect(controllerMock.spawn).to.have.been.calledTwice
-      expect(botMock.startRTM).to.have.been.called
-      expect(storageMock.teams.save).not.to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-  })
-
-  describe('startSingleBot', function () {
-    let testConfig
-    let plugin
-
-    beforeEach(function () {
-      plugin = {
-        init: sinon.stub(),
-        botConnected: sinon.stub()
-      }
-
-      testConfig = {
-        slackToken: 'abc123',
-        plugins: [plugin]
-      }
-    })
-
-    it('should spawn a bot and start rtm', function () {
-      skellington(testConfig)
-      expect(controllerMock.spawn).to.have.been.calledWith({token: 'abc123'})
-      expect(botMock.startRTM).to.have.been.called
-      expect(plugin.init).to.have.been.called
-      expect(plugin.botConnected).to.have.been.called
-    })
-
-    it('should handle error thrown when initializing plugins', function () {
-      plugin.init.throws(err)
-      skellington(testConfig)
-      expect(plugin.init).to.have.been.called
-      expect(plugin.botConnected).to.have.been.called
-    })
-
-    it('should handle err when calling botConnected', function () {
-      plugin.botConnected.throws(err)
-      skellington(testConfig)
-      expect(plugin.init).to.have.been.called
-      expect(plugin.botConnected).to.have.been.called
-    })
-
-    it('should continue if plugin init is missing', function () {
-      delete plugin.init
-      skellington(testConfig)
-      expect(botMock.startRTM).to.have.been.called
-      expect(plugin.botConnected).to.have.been.called
-    })
-
-    it('should continue if plugin botConnected is missing', function () {
-      delete plugin.botConnected
-      skellington(testConfig)
-      expect(botMock.startRTM).to.have.been.called
-      expect(plugin.init).to.have.been.called
-    })
-
-    it('should exit if starting rtm fails', function () {
-      botMock.startRTM.yields(err)
-      skellington(testConfig)
-
-      expect(controllerMock.spawn).to.have.been.calledWith({token: 'abc123'})
-      expect(botMock.startRTM).to.have.been.called
-      expect(process.exit).to.have.been.calledWith(1)
-      expect(plugin.init).not.to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-
-    it('should not exit if starting rtm fails and exitOnRtmFailure is false', function () {
-      botMock.startRTM.yields(err)
-      testConfig.exitOnRtmFailure = false
-      skellington(testConfig)
-
-      expect(controllerMock.spawn).to.have.been.calledWith({token: 'abc123'})
-      expect(botMock.startRTM).to.have.been.called
-      expect(process.exit).not.to.have.been.called
-      expect(plugin.init).not.to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-  })
-
-  describe('event: create_bot', function () {
-    let callback
-    let testConfig
-    let plugin
-    let newBot
-
-    beforeEach(function () {
-      plugin = {
-        botConnected: sinon.stub()
-      }
-
-      testConfig = {
-        slackToken: 'abc123',
-        plugins: [plugin]
-      }
-
-      newBot = {
-        startRTM: sinon.stub().yields(null, newBot),
-        identity: {
-          name: 'rick',
-          id: 'rick'
-        },
-        config: {
-          id: 'ricksanchez'
-        },
-        team_info: {
-          id: 'ricksanchez'
-        }
-      }
-
-      newBot.startRTM.yields(null, newBot)
-
-      skellington(testConfig)
-      plugin.botConnected.reset()
-      callback = getOnCallback('create_bot')
-    })
-
-    it('should start rtm and call botConnected', function () {
-      callback(newBot)
-      expect(newBot.startRTM).to.have.been.called
-      expect(plugin.botConnected).to.have.been.called
-    })
-
-    it('should only connect a bot once', function () {
-      callback(newBot)
-      callback(newBot)
-      expect(newBot.startRTM).to.have.been.calledOnce
-      expect(plugin.botConnected).to.have.been.calledOnce
-    })
-
-    it('should exit if rtm fails', function () {
-      newBot.startRTM.yields(err)
-      callback(newBot)
-      expect(newBot.startRTM).to.have.been.called
-      expect(plugin.botConnected).not.to.have.been.called
-    })
-  })
-
-  describe('event: rtm_close', function () {
-    let callback
-
-    function getRTMCallback(config) {
-
-      skellington(config)
-
-      controllerMock.log.reset()
-      process.exit.reset()
-
-      botMock.startRTM.reset()
-      botMock.startRTM.yields(null)
-
-      return getOnCallback('rtm_close')
-    }
-
-    it('should reconnect', function () {
-      callback = getRTMCallback({slackToken: 'abc'})
-
-      callback(botMock)
-      expect(botMock.startRTM).to.be.calledOnce
-    })
-
-    it('should exit if reconnect fails for single bot', function () {
-      let error = new Error('GAZORPAZORP')
-      callback = getRTMCallback({slackToken: 'abc'})
-
-      botMock.startRTM.yields(error)
-
-      callback(botMock)
-      expect(botMock.startRTM).to.be.calledOnce
-      expect(process.exit).to.be.calledWith(1)
-    })
-
-    it('should not exit if reconnect fails for single bot and exitOnRtmFailure is false', function() {
-      let error = new Error('GAZORPAZORP')
-
-      callback = getRTMCallback({slackToken: 'abc', exitOnRtmFailure: false})
-
-      botMock.startRTM.yields(error)
-
-      callback(botMock)
-      expect(botMock.startRTM).to.be.calledOnce
-      expect(process.exit).not.to.be.called
-    });
-
-    it('should not exit if reconnect fails for a slack app', function() {
-      let error = new Error('GAZORPAZORP')
-
-      callback = getRTMCallback({clientId: 'walter', clientSecret: 'heisenberg'})
-
-      botMock.startRTM.yields(error)
-
-      callback(botMock)
-      expect(botMock.startRTM).to.be.calledOnce
-      expect(process.exit).not.to.be.called
-    });
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -128,6 +128,13 @@ describe('Skellington', function () {
       expect(instance.__config.scopes.sort()).to.deep.equal(['a', 'b', 'c', 'd'])
     })
 
+    it('should add a set of connectedTeams', function() {
+      testConfig.debug = true
+      const instance = skellington(testConfig)
+
+      expect(instance.__config.connectedTeams).to.be.instanceOf(Set)
+    });
+
     it('should exit if required configs are missing', function () {
       skellington({})
       expect(process.exit).to.have.been.calledWith(1)

--- a/test/lib/debug-logger.spec.js
+++ b/test/lib/debug-logger.spec.js
@@ -40,7 +40,7 @@ describe('Debug Logger', function () {
   }
 
   it('should log on a call to hears', function () {
-    logger(controllerMock, testConfig)
+    logger.addLogger(controllerMock, testConfig)
     const loggingMiddleware = getLoggingMiddleware()
 
     expect(hearsMock).to.have.been.called
@@ -50,7 +50,7 @@ describe('Debug Logger', function () {
   })
 
   it('should not log if default hears_test returns false', function () {
-    logger(controllerMock, testConfig)
+    logger.addLogger(controllerMock, testConfig)
     controllerMock.hears_test.returns(false)
     const loggingMiddleware = getLoggingMiddleware()
 
@@ -59,7 +59,7 @@ describe('Debug Logger', function () {
   })
 
   it('should log if middleware returns true', function () {
-    logger(controllerMock, testConfig)
+    logger.addLogger(controllerMock, testConfig)
 
     const middleware = sinon.stub().returns(true)
     controllerMock.hears(patterns, events, middleware, () => {})
@@ -72,7 +72,7 @@ describe('Debug Logger', function () {
   })
 
   it('should not log if middleware returns false', function () {
-    logger(controllerMock, testConfig)
+    logger.addLogger(controllerMock, testConfig)
 
     const middleware = sinon.stub().returns(false)
     controllerMock.hears(patterns, events, middleware, () => {})
@@ -85,7 +85,7 @@ describe('Debug Logger', function () {
 
   it('should allow formatter to be overwritten', function () {
     testConfig.formatter = sinon.stub()
-    logger(controllerMock, testConfig)
+    logger.addLogger(controllerMock, testConfig)
 
     const loggingMiddleware = getLoggingMiddleware()
     loggingMiddleware(patterns, messageMock)
@@ -100,7 +100,7 @@ describe('Debug Logger', function () {
     it('should restore prepareStackTrace', function () {
       // prepareStackTrace gets temporarily overwritten, make sure we restore it
       const prepareStackTraceOrig = Error.prepareStackTrace
-      logger(controllerMock, testConfig)
+      logger.addLogger(controllerMock, testConfig)
       expect(Error.prepareStackTrace).to.equal(prepareStackTraceOrig)
     })
   })

--- a/test/lib/help.spec.js
+++ b/test/lib/help.spec.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const chai = require('chai')
+const expect = chai.expect
+const sinon = require('sinon')
+const _ = require('lodash')
+
+chai.use(require('sinon-chai'))
+
+describe('help', function () {
+  let controllerMock
+  let messageMock
+  let botMock
+  let plugin
+  let help
+
+  beforeEach(function () {
+    controllerMock = {
+      hears: sinon.stub()
+    }
+
+    plugin = {
+      init: sinon.stub()
+    }
+
+    botMock = {
+      reply: sinon.stub(),
+      identity: {
+        name: 'walter'
+      }
+    }
+
+    messageMock = {
+      team: 'crystal',
+      channel: 'blue',
+      user: 'persuasion'
+    }
+
+    help = require('../../lib/help')
+  })
+
+  it('should register a listener if no plugins have help text', function () {
+    help.addHelpListeners(controllerMock, [plugin])
+    expect(controllerMock.hears).to.have.been.calledOnce
+
+    let callback = controllerMock.hears.args[0][2]
+
+    callback(botMock, messageMock)
+    expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^I can't help you/)
+  })
+
+  it('should register a listener for each plugin with help text', function () {
+    plugin.help = {
+      command: 'rick',
+      text: 'sanchez'
+    }
+
+    let anotherPlugin = {
+      init: sinon.stub(),
+      help: {
+        command: 'morty',
+        text: 'smith'
+      }
+    }
+
+    let aThirdPlugin = {init: sinon.stub()}
+
+    help.addHelpListeners(controllerMock, [plugin, anotherPlugin, aThirdPlugin])
+
+    expect(controllerMock.hears.callCount).to.equal(3) // once for general help, twice for plugins with help text
+
+    // call all the callbacks
+    _.forEach(controllerMock.hears.args, function (args) {
+      args[2](botMock, messageMock)
+    })
+
+    expect(botMock.reply).to.have.been.calledWithMatch(messageMock, /^Here are some things/)
+    expect(botMock.reply).to.have.been.calledWith(messageMock, plugin.help.text)
+    expect(botMock.reply).to.have.been.calledWith(messageMock, anotherPlugin.help.text)
+  })
+
+  it('should handle a plugin help text callback', function () {
+    let helpTextCb = sinon.stub()
+
+    plugin.help = {
+      command: 'walter',
+      text: helpTextCb
+    }
+
+    botMock.identity = {name: 'rickandmorty'}
+
+    help.addHelpListeners(controllerMock, [plugin])
+
+    // call all the callbacks
+    _.forEach(controllerMock.hears.args, function (args) {
+      args[2](botMock, messageMock)
+    })
+
+    expect(helpTextCb).to.have.been.calledWith({
+      botName: botMock.identity.name,
+      team: messageMock.team,
+      channel: messageMock.channel,
+      user: messageMock.user
+    })
+  })
+})

--- a/test/lib/plugin-lifecycle.spec.js
+++ b/test/lib/plugin-lifecycle.spec.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const chai = require('chai')
+const expect = chai.expect
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noCallThru()
+
+chai.use(require('sinon-chai'))
+
+describe('plugin-lifecycle', function () {
+  let controllerMock
+  let botMock
+  let utilsMock
+  let lifecycle
+
+  beforeEach(function () {
+    controllerMock = {
+      webserver: 'webserver'
+    }
+
+    botMock = 'bottttt'
+
+    utilsMock = {
+      logError: sinon.stub()
+    }
+
+    lifecycle = proxyquire('../../lib/plugin-lifecycle', {
+      './utils': utilsMock
+    })
+  })
+
+  describe('init', function () {
+    let plugin1
+    let plugin2
+
+    beforeEach(function () {
+      plugin1 = {
+        init: sinon.stub()
+      }
+
+      plugin2 = {
+        init: sinon.stub()
+      }
+    })
+
+    it('should initialize plugins', function () {
+      lifecycle.initialize([plugin1, plugin2], controllerMock, botMock)
+      expect(plugin1.init).to.have.been.calledWith(controllerMock, botMock, controllerMock.webserver)
+      expect(plugin2.init).to.have.been.calledWith(controllerMock, botMock, controllerMock.webserver)
+    })
+
+    it('should use null if bot is not passed', function () {
+      lifecycle.initialize([plugin1], controllerMock)
+      expect(plugin1.init).to.have.been.calledWith(controllerMock, null, controllerMock.webserver)
+    })
+
+    it('should handle an error in initializing a plugin', function () {
+      const err = new Error('GUSFRING')
+      plugin1.init.throws(err)
+
+      lifecycle.initialize([plugin1, plugin2], controllerMock, botMock)
+      expect(plugin1.init).to.have.been.calledWith(controllerMock, botMock, controllerMock.webserver)
+      expect(plugin2.init).to.have.been.calledWith(controllerMock, botMock, controllerMock.webserver)
+    })
+
+    it('should continue if plugin init is missing', function () {
+      delete plugin1.init
+      lifecycle.initialize([plugin1, plugin2], controllerMock, botMock)
+      expect(plugin2.init).to.have.been.called
+    })
+  })
+
+  describe('botConnected', function () {
+    let plugin1
+    let plugin2
+
+    beforeEach(function () {
+      plugin1 = {
+        botConnected: sinon.stub()
+      }
+
+      plugin2 = {
+        botConnected: sinon.stub()
+      }
+    })
+
+    it('should initialize plugins', function () {
+      lifecycle.botConnected([plugin1, plugin2], controllerMock, botMock)
+      expect(plugin1.botConnected).to.have.been.calledWith(controllerMock, botMock)
+      expect(plugin2.botConnected).to.have.been.calledWith(controllerMock, botMock)
+    })
+
+    it('should handle an error in initializing a plugin', function () {
+      const err = new Error('GUSFRING')
+      plugin1.botConnected.throws(err)
+
+      lifecycle.botConnected([plugin1, plugin2], controllerMock, botMock)
+      expect(plugin1.botConnected).to.have.been.calledWith(controllerMock, botMock)
+      expect(plugin2.botConnected).to.have.been.calledWith(controllerMock, botMock)
+    })
+
+    it('should continue if plugin botConnected is missing', function () {
+      delete plugin1.botConnected
+      lifecycle.botConnected([plugin1, plugin2], controllerMock, botMock)
+      expect(plugin2.botConnected).to.have.been.called
+    })
+  })
+})

--- a/test/lib/server.spec.js
+++ b/test/lib/server.spec.js
@@ -1,0 +1,86 @@
+'use strict'
+
+var chai = require('chai')
+var expect = chai.expect
+var sinon = require('sinon')
+var proxyquire = require('proxyquire').noCallThru()
+
+chai.use(require('sinon-chai'))
+
+describe('server', function () {
+  let testConfig
+  let utilsMock
+  let controllerMock
+  let err
+  let server
+
+  beforeEach(function () {
+    utilsMock = {
+      logError: sinon.stub()
+    }
+
+    testConfig = {port: 1234}
+
+    controllerMock = {
+      webserver: 'webserver',
+      setupWebserver: sinon.stub().yields(),
+      createWebhookEndpoints: sinon.stub(),
+      createOauthEndpoints: sinon.stub()
+    }
+
+    err = new Error('GUSFRING')
+
+    server = proxyquire('../../lib/server', {
+      './utils': utilsMock
+    })
+  })
+
+  it('should set up a server if port is passed', function () {
+    server.start(controllerMock, testConfig)
+    expect(controllerMock.setupWebserver).to.have.been.calledWith(1234)
+    expect(controllerMock.createWebhookEndpoints).to.have.been.calledWith(controllerMock.webserver)
+    expect(controllerMock.createOauthEndpoints).to.have.been.calledWith(controllerMock.webserver)
+  })
+
+  it('should not create endpoints if server is not created', function () {
+    controllerMock.setupWebserver.yields(err)
+    server.start(controllerMock, testConfig)
+    expect(controllerMock.setupWebserver).to.have.been.called
+    expect(controllerMock.createWebhookEndpoints).not.to.have.been.called
+    expect(controllerMock.createOauthEndpoints).not.to.have.been.called
+  })
+
+  describe('Oauth callback', function () {
+    let oauthCallback
+    let reqMock
+    let resMock
+
+    beforeEach(function () {
+      server.start(controllerMock, testConfig)
+      oauthCallback = controllerMock.createOauthEndpoints.args[0][1]
+
+      reqMock = {}
+      resMock = {
+        status: sinon.stub(),
+        send: sinon.stub()
+      }
+
+      resMock.status.returns(resMock)
+    })
+
+    it('should respond with 200 and success', function () {
+      oauthCallback(null, reqMock, resMock)
+      expect(resMock.status).to.have.been.calledWith(200)
+      expect(resMock.send).to.have.been.called
+    })
+
+    it('should respond with a 500 and error if oauth fails', function () {
+      utilsMock.logError.reset()
+
+      oauthCallback(err, reqMock, resMock)
+      expect(utilsMock.logError).to.have.been.calledWith(controllerMock, err)
+      expect(resMock.status).to.have.been.calledWith(500)
+      expect(resMock.send).to.have.been.called
+    })
+  })
+})

--- a/test/lib/single-team-bot.spec.js
+++ b/test/lib/single-team-bot.spec.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const chai = require('chai')
+const expect = chai.expect
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noCallThru()
+
+chai.use(require('sinon-chai'))
+
+describe('single-team-bot', function () {
+  let testConfig
+  let plugin
+  let botMock
+  let controllerMock
+  let lifecycleMock
+  let utilsMock
+  let err
+  let singleTeamBot
+
+  beforeEach(function () {
+    plugin = {
+      init: sinon.stub(),
+      botConnected: sinon.stub()
+    }
+
+    botMock = {
+      startRTM: sinon.stub().yields(null, botMock)
+    }
+
+    controllerMock = {
+      spawn: sinon.stub().returns(botMock),
+      log: sinon.stub(),
+      on: sinon.stub()
+    }
+
+    testConfig = {
+      slackToken: 'abc123',
+      plugins: [plugin]
+    }
+
+    lifecycleMock = {
+      initialize: sinon.stub(),
+      botConnected: sinon.stub()
+    }
+
+    utilsMock = {
+      logError: sinon.stub(),
+      identity: sinon.stub()
+    }
+
+    sinon.stub(process, 'exit')
+
+    err = new Error('GUSFRING')
+
+    singleTeamBot = proxyquire('../../lib/single-team-bot', {
+      './plugin-lifecycle': lifecycleMock,
+      './utils': utilsMock
+    })
+  })
+
+  afterEach(function () {
+    process.exit.restore()
+  })
+
+  it('should spawn a bot and start rtm', function () {
+    singleTeamBot.start(controllerMock, testConfig)
+
+    expect(controllerMock.spawn).to.have.been.calledWith({token: 'abc123'})
+    expect(botMock.startRTM).to.have.been.called
+    expect(lifecycleMock.initialize).to.have.been.called
+    expect(lifecycleMock.botConnected).to.have.been.called
+  })
+
+  it('should exit if starting rtm fails', function () {
+    botMock.startRTM.yields(err)
+    singleTeamBot.start(controllerMock, testConfig)
+
+    expect(controllerMock.spawn).to.have.been.calledWith({token: 'abc123'})
+    expect(botMock.startRTM).to.have.been.called
+    expect(process.exit).to.have.been.calledWith(1)
+    expect(lifecycleMock.initialize).not.to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+  })
+
+  it('should not exit if starting rtm fails and exitOnRtmFailure is false', function () {
+    botMock.startRTM.yields(err)
+    testConfig.exitOnRtmFailure = false
+    singleTeamBot.start(controllerMock, testConfig)
+
+    expect(controllerMock.spawn).to.have.been.calledWith({token: 'abc123'})
+    expect(botMock.startRTM).to.have.been.called
+    expect(process.exit).not.to.have.been.called
+    expect(lifecycleMock.initialize).not.to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+  })
+
+  describe('rtm_close', function () {
+    let callback
+
+    function getRTMCallback (config) {
+      singleTeamBot.start(controllerMock, config)
+
+      botMock.startRTM.reset()
+      botMock.startRTM.yields(null)
+
+      return controllerMock.on.args[0][1]
+    }
+
+    it('should reconnect', function () {
+      callback = getRTMCallback({slackToken: 'abc'})
+
+      callback(botMock)
+      expect(botMock.startRTM).to.be.calledOnce
+    })
+
+    it('should exit if reconnect fails', function () {
+      let error = new Error('GAZORPAZORP')
+      callback = getRTMCallback({slackToken: 'abc'})
+
+      botMock.startRTM.yields(error)
+
+      callback(botMock)
+      expect(botMock.startRTM).to.be.calledOnce
+      expect(process.exit).to.be.calledWith(1)
+    })
+
+    it('should not exit if reconnect fails and exitOnRtmFailure is false', function () {
+      let error = new Error('GAZORPAZORP')
+
+      callback = getRTMCallback({slackToken: 'abc', exitOnRtmFailure: false})
+
+      botMock.startRTM.yields(error)
+
+      callback(botMock)
+      expect(botMock.startRTM).to.be.calledOnce
+      expect(process.exit).not.to.be.called
+    })
+  })
+})

--- a/test/lib/slack-app.spec.js
+++ b/test/lib/slack-app.spec.js
@@ -1,0 +1,251 @@
+'use strict'
+
+const chai = require('chai')
+const expect = chai.expect
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noCallThru()
+const _ = require('lodash')
+
+chai.use(require('sinon-chai'))
+
+describe('slack-app', function () {
+  let testConfig
+  let teams
+  let storageMock
+  let controllerMock
+  let botMock
+  let lifecycleMock
+  let utilsMock
+  let err
+  let slackApp
+
+  function getOnCallback (eventName) {
+    return _.find(controllerMock.on.args, (args) => {
+      return args[0] === eventName
+    })[1]
+  }
+
+  beforeEach(function () {
+    testConfig = {
+      port: 1234,
+      clientId: 'walterwhite',
+      clientSecret: 'heisenberg',
+      redirectUri: 'granitestate',
+      plugins: [{}],
+      state: 'newmexico',
+      scopes: ['a'],
+      connectedTeams: new Set()
+    }
+
+    lifecycleMock = {
+      initialize: sinon.stub(),
+      botConnected: sinon.stub()
+    }
+
+    utilsMock = {
+      logError: sinon.stub(),
+      identity: sinon.stub()
+    }
+
+    teams = [{bot: 'team1', id: 'heisenberg'}, {bot: 'team2', id: 'capncook'}]
+
+    storageMock = {
+      teams: {
+        all: sinon.stub().yields(null, teams),
+        save: sinon.stub().yields(null)
+      }
+    }
+
+    botMock = {
+      startRTM: sinon.stub(),
+      team_info: {
+        id: 'heisenberg'
+      },
+      identity: {
+        id: 'walter'
+      }
+    }
+
+    botMock.startRTM.yields(null, botMock)
+
+    controllerMock = {
+      spawn: sinon.stub().returns(botMock),
+      log: sinon.stub(),
+      on: sinon.stub(),
+      configureSlackApp: sinon.stub(),
+      storage: storageMock
+    }
+
+    sinon.stub(process, 'exit')
+
+    err = new Error('GUSFRING')
+
+    slackApp = proxyquire('../../lib/slack-app', {
+      './plugin-lifecycle': lifecycleMock,
+      './utils': utilsMock
+    })
+  })
+
+  afterEach(function () {
+    process.exit.restore()
+  })
+
+  it('should configure a slack app and initialize plugins', function () {
+    slackApp.start(controllerMock, testConfig)
+
+    expect(controllerMock.configureSlackApp).to.have.been.calledWith({
+      clientId: testConfig.clientId,
+      clientSecret: testConfig.clientSecret,
+      redirectUri: testConfig.redirectUri, // optional
+      state: testConfig.state,
+      scopes: testConfig.scopes
+    })
+
+    expect(lifecycleMock.initialize).to.have.been.calledWith(testConfig.plugins, controllerMock, null)
+  })
+
+  it('should read teams from storage and reconnnect them', function () {
+    slackApp.start(controllerMock, testConfig)
+
+    expect(storageMock.teams.all).to.have.been.called
+    expect(controllerMock.spawn).to.have.been.calledTwice
+    expect(botMock.startRTM).to.have.been.called
+    expect(lifecycleMock.botConnected).to.have.been.called
+  })
+
+  it('should not start rtm if team does not have a bot', function () {
+    teams = [{}, {}]
+    storageMock.teams.all.yields(null, teams)
+    slackApp.start(controllerMock, testConfig)
+
+    expect(storageMock.teams.all).to.have.been.called
+    expect(controllerMock.spawn).not.to.have.been.calledTwice
+    expect(botMock.startRTM).not.to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+  })
+
+  it('should exit if it cannot read teams from storage', function () {
+    storageMock.teams.all.yields(err)
+    slackApp.start(controllerMock, testConfig)
+
+    expect(storageMock.teams.all).to.have.been.called
+    expect(controllerMock.spawn).not.to.have.been.calledTwice
+    expect(botMock.startRTM).not.to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+    expect(process.exit).to.have.been.calledWith(1)
+  })
+
+  it('should remove team for account_inactive error', function () {
+    botMock.startRTM.yields('account_inactive')
+    slackApp.start(controllerMock, testConfig)
+
+    expect(storageMock.teams.all).to.have.been.called
+    expect(controllerMock.spawn).to.have.been.calledTwice
+    expect(botMock.startRTM).to.have.been.called
+    expect(storageMock.teams.save).to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+  })
+
+  it('should remove team for invalid_auth error', function () {
+    botMock.startRTM.yields('invalid_auth')
+    slackApp.start(controllerMock, testConfig)
+
+    expect(storageMock.teams.all).to.have.been.called
+    expect(controllerMock.spawn).to.have.been.calledTwice
+    expect(botMock.startRTM).to.have.been.called
+    expect(storageMock.teams.save).to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+  })
+
+  it('should not remove team for other errors', function () {
+    botMock.startRTM.yields('two dots')
+    slackApp.start(controllerMock, testConfig)
+
+    expect(storageMock.teams.all).to.have.been.called
+    expect(controllerMock.spawn).to.have.been.calledTwice
+    expect(botMock.startRTM).to.have.been.called
+    expect(storageMock.teams.save).not.to.have.been.called
+    expect(lifecycleMock.botConnected).not.to.have.been.called
+  })
+
+  describe('event: create_bot', function () {
+    let callback
+    let testConfig
+    let newBot
+
+    beforeEach(function () {
+      testConfig = {
+        slackToken: 'abc123',
+        plugins: [{}],
+        connectedTeams: new Set()
+      }
+
+      newBot = {
+        startRTM: sinon.stub().yields(null, newBot),
+        identity: {
+          name: 'rick',
+          id: 'rick'
+        },
+        config: {
+          id: 'ricksanchez'
+        },
+        team_info: {
+          id: 'ricksanchez'
+        }
+      }
+
+      newBot.startRTM.yields(null, newBot)
+
+      slackApp.start(controllerMock, testConfig)
+      lifecycleMock.botConnected.reset()
+      callback = getOnCallback('create_bot')
+    })
+
+    it('should start rtm and call botConnected', function () {
+      callback(newBot)
+      expect(newBot.startRTM).to.have.been.called
+      expect(lifecycleMock.botConnected).to.have.been.called
+    })
+
+    it('should only connect a bot once', function () {
+      callback(newBot)
+      callback(newBot)
+      expect(newBot.startRTM).to.have.been.calledOnce
+      expect(lifecycleMock.botConnected).to.have.been.calledOnce
+    })
+
+    it('should exit if rtm fails', function () {
+      newBot.startRTM.yields(err)
+      callback(newBot)
+      expect(newBot.startRTM).to.have.been.called
+      expect(lifecycleMock.botConnected).not.to.have.been.called
+    })
+  })
+
+  describe('event: rtm_close', function () {
+    let callback
+
+    beforeEach(function () {
+      slackApp.start(controllerMock, testConfig)
+
+      botMock.startRTM.reset()
+      botMock.startRTM.yields(null)
+
+      callback = getOnCallback('rtm_close')
+    })
+
+    it('should reconnect', function () {
+      callback(botMock)
+      expect(botMock.startRTM).to.be.calledOnce
+    })
+
+    it('should not exit if reconnect fails', function () {
+      let error = new Error('GAZORPAZORP')
+      botMock.startRTM.yields(error)
+
+      callback(botMock)
+      expect(botMock.startRTM).to.be.calledOnce
+      expect(process.exit).not.to.be.called
+    })
+  })
+})


### PR DESCRIPTION
I refactored the app into stateless services. Keeping them stateless allows for multiple instances of Skellington to be run from within the same process.

The main index.js file is now responsible for formatting the config correctly and calling other services based on the state of the config. Everything else should have clear responsibilities.